### PR TITLE
django-authority for Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "Framework :: Django",
     ],
     install_requires=["django"],
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools_scm==5.0.2"],
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
:exclamation: Don't delete this PR :exclamation:

It is necessary for applications that are still using python 2.7. 